### PR TITLE
Improvement of the modularity of the grasp pose generator

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -625,7 +625,7 @@ class GraspProcessorModule : public RFModule
                 vector<Matrix> refined_grasp_pose_candidates;
                 this->refineGraspPoseCandidates(super_quadric_parameters, raw_grasp_pose_candidates, refined_grasp_pose_candidates);
 
-                if(refined_grasp_pose_candidates.size()>0)
+                if((refined_grasp_pose_candidates.front().cols()==4) && (refined_grasp_pose_candidates.front().rows()==4))
                 {
                     reply.addString("ok");
                     for(int i=0 ; i<3 ; i++) reply.addDouble(refined_grasp_pose_candidates.front()(i,3));
@@ -1016,6 +1016,10 @@ class GraspProcessorModule : public RFModule
                 pose_candidate.setSubmatrix(pose_mat_rotation, 0,0);
                 refined_grasp_pose_candidates.push_back(pose_candidate);
             }
+            else
+            {
+                refined_grasp_pose_candidates.push_back(Matrix());
+            }
         }
     }
 
@@ -1107,6 +1111,8 @@ class GraspProcessorModule : public RFModule
         pose_candidates.clear();
         for(size_t idx=0 ; idx<refined_grasp_pose_candidates.size() ; idx++)
         {
+            if((refined_grasp_pose_candidates[idx].rows()!=4) || (refined_grasp_pose_candidates[idx].cols()!=4)) continue;
+
             shared_ptr<GraspPose> candidate_pose = shared_ptr<GraspPose>(new GraspPose);
 
             candidate_pose->pose_translation = refined_grasp_pose_candidates[idx].subcol(0,3,3);
@@ -1116,6 +1122,7 @@ class GraspProcessorModule : public RFModule
 
             Matrix pose_superq_mat_rotation = raw_grasp_pose_candidates[idx].submatrix(0,2,0,2).transposed() * superq_mat_orientation;
             candidate_pose->pose_ax_size.zero();
+
             for(int i=0 ; i<3 ; i++)
             {
                 for(int j=0 ; j<3 ; j++)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -906,6 +906,12 @@ class GraspProcessorModule : public RFModule
         //  if fixate_object is given, look at the object before acquiring the point cloud
         if (fixate_object)
         {
+            if(action_render_rpc.getOutputCount()<1)
+            {
+                yError() << "requestRefreshPointCloud: no connection to action rendering module";
+                return false;
+            }
+
             cmd_request.addString("look");
             cmd_request.addString(object);
             cmd_request.addString("wait");
@@ -924,6 +930,12 @@ class GraspProcessorModule : public RFModule
 
         cmd_request.addString("get_point_cloud");
         cmd_request.addString(object);
+
+        if(point_cloud_rpc.getOutputCount()<1)
+        {
+            yError() << "requestRefreshPointCloud: no connection to point cloud module";
+            return false;
+        }
 
         point_cloud_rpc.write(cmd_request, cmd_reply);
 
@@ -954,6 +966,12 @@ class GraspProcessorModule : public RFModule
         //  refresh superquadric with parameters
         Bottle sq_reply;
         sq_reply.clear();
+
+        if(superq_rpc.getOutputCount()<1)
+        {
+            yError() << "requestRefreshSuperquadric: no connection to superquadric module";
+            return false;
+        }
 
         superq_rpc.write(point_cloud, sq_reply);
 


### PR DESCRIPTION
The changes aim at decoupling the inner parts of the module from one another to improve the usability from external modules.

Mainly the pipeline has been cut into several parts to decouple the computation from the display and from the hardware (robot):
- generation of generic grasping poses given a superquadric
- refinement of the poses to fit specific constraints (table, robot design, ...) 

(The current modified version should give similar results to the previous version, but further tests are required.
Developments are not finished, but I open the pull request for potential discussions.)
