### PR TITLE
Further extension of the module

### DIFF
--- a/app/conf/config-icub.ini
+++ b/app/conf/config-icub.ini
@@ -12,4 +12,4 @@ approach_left (-0.05 0.0 +0.05 0.0)
 grasp_bounding_box (-0.0 0.08 -0.048 0.032 -0.0 0.072)
 planar_obstacle (0.0 0.0 1.0 0.15)
 obstacle_safety_distance 0.01
-
+position_error_threshold 0.01

--- a/app/conf/config-icub.ini
+++ b/app/conf/config-icub.ini
@@ -3,6 +3,8 @@ x 1400
 y 220
 width 600
 height 600
+min_object_size (0.0 0.04 0.0)
+max_object_size (0.12 10.0 10.0)
 grasp_trsfm_right (-0.01 0.0 0.0 0.0 1.0 0.0 -0.663225116)
 grasp_trsfm_left (-0.01 0.0 0.0 0.0 1.0 0.0 0.663225116)
 approach_right (-0.05 0.0 -0.05 0.0)

--- a/app/conf/config-icub.ini
+++ b/app/conf/config-icub.ini
@@ -9,8 +9,8 @@ grasp_trsfm_right (-0.01 0.0 0.0 0.0 1.0 0.0 -0.663225116)
 grasp_trsfm_left (-0.01 0.0 0.0 0.0 1.0 0.0 0.663225116)
 approach_right (-0.05 0.0 -0.05 0.0)
 approach_left (-0.05 0.0 +0.05 0.0)
-grasp_bounding_box_right (-0.0 0.08 -0.048 0.032 -0.0 0.072)
-grasp_bounding_box_left (-0.0 0.08 -0.048 0.032 -0.072 0.0)
+grasp_bounding_box_right (-0.0 0.05 -0.05 0.05 -0.0 0.05)
+grasp_bounding_box_left (-0.0 0.05 -0.05 0.05 -0.05 0.0)
 planar_obstacle (0.0 0.0 1.0 0.15)
-obstacle_safety_distance 0.01
+obstacle_safety_distance 0.005
 position_error_threshold 0.01

--- a/app/conf/config-icub.ini
+++ b/app/conf/config-icub.ini
@@ -9,7 +9,8 @@ grasp_trsfm_right (-0.01 0.0 0.0 0.0 1.0 0.0 -0.663225116)
 grasp_trsfm_left (-0.01 0.0 0.0 0.0 1.0 0.0 0.663225116)
 approach_right (-0.05 0.0 -0.05 0.0)
 approach_left (-0.05 0.0 +0.05 0.0)
-grasp_bounding_box (-0.0 0.08 -0.048 0.032 -0.0 0.072)
+grasp_bounding_box_right (-0.0 0.08 -0.048 0.032 -0.0 0.072)
+grasp_bounding_box_left (-0.0 0.08 -0.048 0.032 -0.072 0.0)
 planar_obstacle (0.0 0.0 1.0 0.15)
 obstacle_safety_distance 0.01
 position_error_threshold 0.01

--- a/app/conf/config-r1.ini
+++ b/app/conf/config-r1.ini
@@ -4,12 +4,13 @@ y 200
 width 600
 height 600
 min_object_size (0.0 0.0 0.0)
-max_object_size (10.0 10.0 10.0)
-grasp_trsfm_right (-0.01 0.0 0.0 0.0 1.0 0.0 -0.663225116)
-grasp_trsfm_left (-0.01 0.0 0.0 0.0 1.0 0.0 0.663225116)
+max_object_size (10.0 10.0 0.08)
+grasp_trsfm_right (0.0 0.0 -0.01 0.0 1.0 0.0 -1.570796327)
+grasp_trsfm_left (0.0 0.0 -0.01 0.0 1.0 0.0 1.570796327)
 approach_right (-0.1 0.0 0.0 0.0)
 approach_left (-0.1 0.0 0.0 0.0)
-grasp_bounding_box (-0.0 0.08 -0.048 0.032 -0.0 0.072)
+grasp_bounding_box_right (-0.0 0.085 -0.035 0.035 -0.05 0.04)
+grasp_bounding_box_left (-0.0 0.085 -0.035 0.035 -0.04 0.05)
 planar_obstacle (0.0 0.0 1.0 0.15)
 obstacle_safety_distance 0.01
 position_error_threshold 0.01

--- a/app/conf/config-r1.ini
+++ b/app/conf/config-r1.ini
@@ -12,4 +12,4 @@ approach_left (-0.1 0.0 0.0 0.0)
 grasp_bounding_box (-0.0 0.08 -0.048 0.032 -0.0 0.072)
 planar_obstacle (0.0 0.0 1.0 0.15)
 obstacle_safety_distance 0.01
-
+position_error_threshold 0.01

--- a/app/conf/config-r1.ini
+++ b/app/conf/config-r1.ini
@@ -3,6 +3,8 @@ x 1400
 y 200
 width 600
 height 600
+min_object_size (0.0 0.0 0.0)
+max_object_size (10.0 10.0 10.0)
 grasp_trsfm_right (-0.01 0.0 0.0 0.0 1.0 0.0 -0.663225116)
 grasp_trsfm_left (-0.01 0.0 0.0 0.0 1.0 0.0 0.663225116)
 approach_right (-0.1 0.0 0.0 0.0)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -703,7 +703,17 @@ class GraspProcessorModule : public RFModule
             }
 
             yInfo() << "Pose retrieved: " << grasp_pose.toString();
-            cmd_success = executeGrasp(grasp_pose);
+
+            if (!executeGrasp(grasp_pose))
+            {
+                yError() << prettyError( __FUNCTION__,  "Could not perform the grasping.");
+                reply.addVocab(Vocab::encode("nack"));
+                return true;
+            }
+
+            yInfo() << obj << "grasped";
+            reply.addVocab(Vocab::encode("ack"));
+            return true;
         }
 
         if (command.get(0).toString() == "grasp_from_position")
@@ -814,7 +824,17 @@ class GraspProcessorModule : public RFModule
             }
 
             yInfo() << "Pose retrieved: " << grasp_pose.toString();
-            cmd_success = executeGrasp(grasp_pose);
+
+            if (!executeGrasp(grasp_pose))
+            {
+                yError() << prettyError( __FUNCTION__,  "Could not perform the grasping.");
+                reply.addVocab(Vocab::encode("nack"));
+                return true;
+            }
+
+            yInfo() << "Object grasped";
+            reply.addVocab(Vocab::encode("ack"));
+            return true;
         }
 
         if (command.get(0).toString() == "from_off_file")

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -174,6 +174,9 @@ class GraspProcessorModule : public RFModule
     Vector grasper_approach_parameters_right;
     Vector grasper_approach_parameters_left;
 
+    // Filtering constants
+    double position_error_threshold;
+
     //  visualization parameters
     int x, y, h, w;
 
@@ -374,6 +377,9 @@ class GraspProcessorModule : public RFModule
 
         obstacle_safety_distance = rf.check("obstacle_safety_distance", Value(0.0)).asDouble();
         yInfo() << "Obstacle safety distance loaded=" << obstacle_safety_distance;
+
+        position_error_threshold = rf.check("position_error_threshold", Value(0.01)).asDouble();
+        yInfo() << "Position error threshold loaded=" << position_error_threshold;
 
         //  open the necessary ports
         superq_rpc.open("/" + moduleName + "/superquadricRetrieve:rpc");
@@ -1883,10 +1889,9 @@ class GraspProcessorModule : public RFModule
 
         //  compose a vector of cost functions
         vector <CostEntry> sorted_costs;
-        double position_threshold = 0.01;
         for (size_t i=0; i<costs.size(); i++)
         {
-            if (costs[i][0] < position_threshold)
+            if (costs[i][0] < position_error_threshold)
                 sorted_costs.push_back(CostEntry(costs[i], grasp_pose_candidates[i], i));
         }
 
@@ -2102,7 +2107,8 @@ public:
         planar_obstacle(4, 0.0), grasper_bounding_box(6, 0.0), obstacle_safety_distance(0.005),
         grasping_hand(WhichHand::HAND_RIGHT), min_object_size(3, 0.0), max_object_size(3, std::numeric_limits<double>::max()),
         grasper_specific_transform_right(eye(4,4)), grasper_specific_transform_left(eye(4,4)),
-        grasper_approach_parameters_right(4, 0.0), grasper_approach_parameters_left(4, 0.0)
+        grasper_approach_parameters_right(4, 0.0), grasper_approach_parameters_left(4, 0.0),
+        position_error_threshold(0.01)
     {
         planar_obstacle[2] = 1;
         planar_obstacle[3] = -(-0.15);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -678,7 +678,7 @@ class GraspProcessorModule : public RFModule
                 return true;
             }
 
-            if (computeGraspPose(grasp_pose))
+            if (!computeGraspPose(grasp_pose))
             {
                 yError() << prettyError( __FUNCTION__,  "Could not compute grasping pose.");
                 reply.addVocab(Vocab::encode("nack"));
@@ -753,9 +753,6 @@ class GraspProcessorModule : public RFModule
                 return true;
             }
 
-            PointCloud<DataXYZRGBA> pc;
-            yDebug() << "Requested object: " << obj;
-
             if(halt_requested)
             {
                 yInfo() << "Halt requested before end of process";
@@ -763,6 +760,7 @@ class GraspProcessorModule : public RFModule
                 return true;
             }
 
+            PointCloud<DataXYZRGBA> pc;
             if (!requestRefreshPointCloudFromPosition(pc, position3d, fixate_object))
             {
                 yError() << prettyError( __FUNCTION__,  "Could not refresh point cloud.");
@@ -791,7 +789,7 @@ class GraspProcessorModule : public RFModule
                 return true;
             }
 
-            if (computeGraspPose(grasp_pose))
+            if (!computeGraspPose(grasp_pose))
             {
                 yError() << prettyError( __FUNCTION__,  "Could not compute grasping pose.");
                 reply.addVocab(Vocab::encode("nack"));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1442,7 +1442,7 @@ class GraspProcessorModule : public RFModule
          * 4 - palm cannot point up
          */
 
-        bool ok1, ok2, ok3, ok4;
+        bool ok1=true, ok2=true, ok3=false, ok4=false;
         for(int i=0 ; i<3 ; i++)
         {
             double object_size = 2*pose_ax_size[i];

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1132,12 +1132,14 @@ class GraspProcessorModule : public RFModule
         {
             halt_requested = false;
             reply.addVocab(Vocab::encode("ack"));
+            return true;
         }
 
         if (command.get(0).toString() == "halt")
         {
             halt_requested = true;
             reply.addVocab(Vocab::encode("ack"));
+            return true;
         }
 
         reply.addVocab(Vocab::encode(cmd_success ? "ack":"nack"));
@@ -1981,11 +1983,13 @@ class GraspProcessorModule : public RFModule
             {
                 yWarning() << "Couldn't retrieve fixed pose. Continuing with unchanged pose";
             }
-
-        //  if we are working with the simulator or there is no calib map, the pose doesn't need to be corrected
-        poseFixed = poseToFix;
-        yWarning() << "Connection to iolReachingCalibration not detected or calibration map not present: pose will not be changed";
-        return true;
+        }
+        else
+        {
+            //  if we are working with the simulator or there is no calib map, the pose doesn't need to be corrected
+            poseFixed = poseToFix;
+            yWarning() << "Connection to iolReachingCalibration not detected or calibration map not present: pose will not be changed";
+            return true;
         }
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -129,7 +129,6 @@ class GraspProcessorModule : public RFModule
     RpcClient superq_rpc;
     RpcClient point_cloud_rpc;
     RpcClient action_render_rpc;
-    RpcClient action_render_rpc_interrupt;
     RpcClient reach_calib_rpc;
     RpcClient table_calib_rpc;
     RpcServer module_rpc;   //will be replaced by idl services
@@ -386,7 +385,6 @@ class GraspProcessorModule : public RFModule
         superq_rpc.open("/" + moduleName + "/superquadricRetrieve:rpc");
         point_cloud_rpc.open("/" + moduleName + "/pointCloud:rpc");
         action_render_rpc.open("/" + moduleName + "/actionRenderer:rpc");
-        action_render_rpc_interrupt.open("/" + moduleName + "/actionRendererInterrupt:rpc");
         reach_calib_rpc.open("/" + moduleName + "/reachingCalibration:rpc");
         table_calib_rpc.open("/" + moduleName + "/tableCalib:rpc");
         module_rpc.open("/" + moduleName + "/cmd:rpc");
@@ -525,7 +523,6 @@ class GraspProcessorModule : public RFModule
         superq_rpc.interrupt();
         point_cloud_rpc.interrupt();
         action_render_rpc.interrupt();
-        action_render_rpc_interrupt.interrupt();
         reach_calib_rpc.interrupt();
         module_rpc.interrupt();
         table_calib_rpc.interrupt();
@@ -540,7 +537,6 @@ class GraspProcessorModule : public RFModule
         superq_rpc.close();
         point_cloud_rpc.close();
         action_render_rpc.close();
-        action_render_rpc_interrupt.close();
         reach_calib_rpc.close();
         module_rpc.close();
         table_calib_rpc.close();
@@ -1135,33 +1131,13 @@ class GraspProcessorModule : public RFModule
         if (command.get(0).toString() == "restart")
         {
             halt_requested = false;
-            if(action_render_rpc_interrupt.getOutputCount()>0)
-            {
-                Bottle command;
-                command.addString("reinstate");
-
-                Bottle rep;
-                action_render_rpc_interrupt.write(command, rep);
-            }
             reply.addVocab(Vocab::encode("ack"));
-            return true;
         }
 
         if (command.get(0).toString() == "halt")
         {
             halt_requested = true;
-
-            if(action_render_rpc_interrupt.getOutputCount()>0)
-            {
-                Bottle command;
-                command.addString("interrupt");
-
-                Bottle rep;
-                action_render_rpc_interrupt.write(command, rep);
-            }
-
             reply.addVocab(Vocab::encode("ack"));
-            return true;
         }
 
         reply.addVocab(Vocab::encode(cmd_success ? "ack":"nack"));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1298,7 +1298,6 @@ class GraspProcessorModule : public RFModule
 
         //  if fixate_object is given, look at the object before acquiring the point cloud
 
-        /* TO FIX
         if (fixate_object)
         {
             if(action_render_rpc.getOutputCount()<1)
@@ -1308,7 +1307,9 @@ class GraspProcessorModule : public RFModule
             }
 
             cmd_request.addVocab(Vocab::encode("look"));
-            cmd_request.addString(object);
+            Bottle &subcmd_request = cmd_request.addList();
+            subcmd_request.addString("cartesian");
+            for(int i=0 ; i<3 ; i++) subcmd_request.addDouble(position[i]);
             cmd_request.addString("wait");
 
             action_render_rpc.write(cmd_request, cmd_reply);
@@ -1317,7 +1318,7 @@ class GraspProcessorModule : public RFModule
                 yError() << prettyError( __FUNCTION__,  "Didn't manage to look at the object");
                 return false;
             }
-        }*/
+        }
 
         point_cloud.clear();
         cmd_request.clear();


### PR DESCRIPTION
- add configurable parameters related to the object size for grasping filtering
- add a way to stop in the middle of a grasp request
- add the possibility to grasp an object given a 3d position instead of a name

Some questions:
- is it possible to call the gaze controller by giving it a 3d position instead of an object name?
- is it possible to stop in the middle of the grasping process performed by `action-gateway`?