### PR TITLE
cardinal points grasp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# grasp-pose-gen
+# cardinal-points-grasp
 
 Simple superquadric-based grasping pose generator and renderer for iCub 
 
@@ -12,7 +12,7 @@ Simple superquadric-based grasping pose generator and renderer for iCub
 
 ### Installation
 ```
-git clone https://github.com/fbottarel/grasp-pose-gen.git
+git clone https://github.com/fbottarel/cardinal-points-grasp.git
 cd grasp-pose-gen
 mkdir build && cd build
 cmake ../


### PR DESCRIPTION
Why don't we go for `cardinal-points-grasp` for the name of the repository?
The changes should be very limited.

Nothing won't change in terms of xml, port names, binary names.
Most likely, we would only need to update some references to this repo.