### PR TITLE
Moonshot mobile manipulation

### DIFF
--- a/app/conf/config-icub.ini
+++ b/app/conf/config-icub.ini
@@ -14,3 +14,5 @@ grasp_bounding_box_left (-0.0 0.05 -0.05 0.05 -0.05 0.0)
 planar_obstacle (0.0 0.0 1.0 0.15)
 obstacle_safety_distance 0.005
 position_error_threshold 0.01
+roundness_threshold 1.0
+nb_cardinal_levels 1

--- a/app/conf/config-icub.ini
+++ b/app/conf/config-icub.ini
@@ -6,7 +6,7 @@ height 600
 min_object_size (0.0 0.04 0.0)
 max_object_size (0.12 10.0 10.0)
 grasp_trsfm_right (-0.01 0.0 0.0 0.0 1.0 0.0 -0.663225116)
-grasp_trsfm_left (-0.01 0.0 0.0 0.0 1.0 0.0 0.663225116)
+grasp_trsfm_left (0.01 0.0 0.0 0.0 1.0 0.0 -2.478367538)
 approach_right (-0.05 0.0 -0.05 0.0)
 approach_left (-0.05 0.0 +0.05 0.0)
 grasp_bounding_box_right (-0.0 0.05 -0.05 0.05 -0.0 0.05)

--- a/app/conf/config-icub.ini
+++ b/app/conf/config-icub.ini
@@ -4,7 +4,7 @@ y 220
 width 600
 height 600
 min_object_size (0.0 0.04 0.0)
-max_object_size (0.12 10.0 10.0)
+max_object_size (0.075 10.0 10.0)
 grasp_trsfm_right (-0.01 0.0 0.0 0.0 1.0 0.0 -0.663225116)
 grasp_trsfm_left (0.01 0.0 0.0 0.0 1.0 0.0 -2.478367538)
 approach_right (-0.05 0.0 -0.05 0.0)

--- a/app/conf/config-r1-pseudo-points.ini
+++ b/app/conf/config-r1-pseudo-points.ini
@@ -1,0 +1,18 @@
+robot "r1"
+x 1400
+y 200
+width 600
+height 600
+min_object_size (0.0 0.0 0.0)
+max_object_size (0.08 10.0 10.0)
+grasp_trsfm_right (0.0 0.0 -0.02 0.0 1.0 0.0 -1.570796327)
+grasp_trsfm_left (0.0 0.0 -0.02 0.0 1.0 0.0 -1.570796327)
+approach_right (-0.1 0.0 0.0 0.0)
+approach_left (-0.1 0.0 0.0 0.0)
+grasp_bounding_box_right (-0.0 0.085 -0.035 0.035 -0.05 0.04)
+grasp_bounding_box_left (-0.0 0.085 -0.035 0.035 -0.04 0.05)
+planar_obstacle (0.0 0.0 1.0 0.15)
+obstacle_safety_distance 0.01
+position_error_threshold 0.01
+roundness_threshold 0.1
+nb_cardinal_levels 2

--- a/app/conf/config-r1.ini
+++ b/app/conf/config-r1.ini
@@ -6,7 +6,7 @@ height 600
 min_object_size (0.0 0.0 0.0)
 max_object_size (0.08 10.0 10.0)
 grasp_trsfm_right (0.0 0.0 -0.01 0.0 1.0 0.0 -1.570796327)
-grasp_trsfm_left (0.0 0.0 -0.01 0.0 1.0 0.0 1.570796327)
+grasp_trsfm_left (0.0 0.0 -0.01 0.0 1.0 0.0 -1.570796327)
 approach_right (-0.1 0.0 0.0 0.0)
 approach_left (-0.1 0.0 0.0 0.0)
 grasp_bounding_box_right (-0.0 0.085 -0.035 0.035 -0.05 0.04)

--- a/app/conf/config-r1.ini
+++ b/app/conf/config-r1.ini
@@ -14,3 +14,5 @@ grasp_bounding_box_left (-0.0 0.085 -0.035 0.035 -0.04 0.05)
 planar_obstacle (0.0 0.0 1.0 0.15)
 obstacle_safety_distance 0.01
 position_error_threshold 0.01
+roundness_threshold 1.0
+nb_cardinal_levels 1

--- a/app/conf/config-r1.ini
+++ b/app/conf/config-r1.ini
@@ -4,7 +4,7 @@ y 200
 width 600
 height 600
 min_object_size (0.0 0.0 0.0)
-max_object_size (10.0 10.0 0.08)
+max_object_size (0.08 10.0 10.0)
 grasp_trsfm_right (0.0 0.0 -0.01 0.0 1.0 0.0 -1.570796327)
 grasp_trsfm_left (0.0 0.0 -0.01 0.0 1.0 0.0 1.570796327)
 approach_right (-0.1 0.0 0.0 0.0)

--- a/include/objectsLib.h
+++ b/include/objectsLib.h
@@ -110,6 +110,8 @@ public:
     /****************************************************************/
     yarp::sig::Vector getOrientationXYZW();
 
+    /****************************************************************/
+    yarp::sig::Vector getRoundness();
 };
 
 class GraspPose

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -501,7 +501,8 @@ class GraspProcessorModule : public RFModule
         vtk_renderer->SetActiveCamera(vtk_camera);
 
         //  prepare the pose actors vector
-        for (size_t idx = 0; idx < 25; idx++)
+
+        for (size_t idx = 0; idx < 6*pow(2, nb_cardinal_levels+1); idx++)
         {
             vtkSmartPointer<vtkAxesActor> ax_actor = vtkSmartPointer<vtkAxesActor>::New();
             vtkSmartPointer<vtkCaptionActor2D> cap_actor = vtkSmartPointer<vtkCaptionActor2D>::New();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -178,6 +178,10 @@ class GraspProcessorModule : public RFModule
     // Filtering constants
     double position_error_threshold;
 
+    // Candidate pose generation parameters
+    double roundness_threshold; // threshold on the roundness of the object to generate pseudo cardinal poses
+    int nb_cardinal_levels; // number of levels of pseudo cardinal poses generated (1 or lower = normal)
+
     //  visualization parameters
     int x, y, h, w;
 
@@ -395,6 +399,16 @@ class GraspProcessorModule : public RFModule
 
         position_error_threshold = rf.check("position_error_threshold", Value(0.01)).asDouble();
         yInfo() << "Position error threshold loaded=" << position_error_threshold;
+
+        roundness_threshold = rf.check("roundness_threshold", Value(1.0)).asDouble();
+        yInfo() << "Roundness threshold loaded=" << roundness_threshold;
+
+        nb_cardinal_levels = rf.check("nb_cardinal_levels", Value(1)).asInt();
+        if(nb_cardinal_levels < 1)
+        {
+            nb_cardinal_levels = 1;
+        }
+        yInfo() << "Number of cardinal point levels loaded=" << nb_cardinal_levels;
 
         //  open the necessary ports
         superq_rpc.open("/" + moduleName + "/superquadricRetrieve:rpc");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1476,9 +1476,10 @@ class GraspProcessorModule : public RFModule
          * 2 - object small enough for grasping
          * 3 - thumb cannot point down
          * 4 - palm cannot point up
+         * 5 - fingers cannot point up
          */
 
-        bool ok1=true, ok2=true, ok3=false, ok4=false;
+        bool ok1=true, ok2=true, ok3=false, ok4=false, ok5=false;
         for(int i=0 ; i<3 ; i++)
         {
             double object_size = 2*pose_ax_size[i];
@@ -1486,19 +1487,30 @@ class GraspProcessorModule : public RFModule
             ok2 &= (object_size < max_object_size[i]);
         }
 
-        ok3 = dot(pose_mat_rotation.getCol(1), root_z_axis) <= 0.1;
+        Matrix hand_mat_rotation;
+        if(grasping_hand == WhichHand::HAND_RIGHT)
+        {
+            hand_mat_rotation = pose_mat_rotation * grasper_specific_transform_right.submatrix(0,2, 0,2);
+        }
+        else
+        {
+            hand_mat_rotation = pose_mat_rotation * grasper_specific_transform_left.submatrix(0,2, 0,2);
+        }
+
+        ok3 = dot(hand_mat_rotation.getCol(1), root_z_axis) <= 0.1;
         if (grasping_hand == WhichHand::HAND_RIGHT)
         {
             //  ok if hand z axis points downward
-            ok4 = (dot(pose_mat_rotation.getCol(2), root_z_axis) <= 0.1);
+            ok4 = (dot(hand_mat_rotation.getCol(2), root_z_axis) <= 0.1);
         }
         else
         {
             //  ok if hand z axis points upwards
-            ok4 = (dot(pose_mat_rotation.getCol(2), root_z_axis) >= -0.1);
+            ok4 = (dot(hand_mat_rotation.getCol(2), root_z_axis) >= -0.1);
         }
+        ok5 = dot(hand_mat_rotation.getCol(0), root_z_axis) <= 0.1;
 
-        return (ok1 && ok2 && ok3 && ok4);
+        return (ok1 && ok2 && ok3 && ok4 && ok5);
     }
 
     /****************************************************************/

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2282,7 +2282,22 @@ class GraspProcessorModule : public RFModule
 
                 pose_candidates[idx]->pose_cost_function = costs[idx];
                 stringstream ss;
-                ss << fixed << setprecision(3) << pose_candidates[idx]->pose_cost_function(0) << "_" << fixed << setprecision(3) << pose_candidates[idx]->pose_cost_function(1);
+                if(pose_candidates[idx]->pose_cost_function(0)==std::numeric_limits<double>::max())
+                {
+                    ss << "max_";
+                }
+                else
+                {
+                    ss << fixed << setprecision(3) << pose_candidates[idx]->pose_cost_function(0) << "_";
+                }
+                if(pose_candidates[idx]->pose_cost_function(1)==std::numeric_limits<double>::max())
+                {
+                    ss << "max";
+                }
+                else
+                {
+                    ss << fixed << setprecision(3) << pose_candidates[idx]->pose_cost_function(1);
+                }
                 pose_candidates[idx]->setvtkActorCaption(ss.str());
 
                 pose_captions[idx]->VisibilityOn();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1585,9 +1585,8 @@ class GraspProcessorModule : public RFModule
          * Filtering parameters:
          * 1 - object large enough for grasping
          * 2 - object small enough for grasping
-         * 3 - thumb cannot point down
-         * 4 - palm cannot point up
-         * 5 - fingers cannot point up
+         * 3 - thumb cannot point down (with 10 degrees margin)
+         * 4 - grasping from top(with 10 degrees margin)
          */
 
         bool ok1=true, ok2=true, ok3=false, ok4=false, ok5=false;
@@ -1608,20 +1607,11 @@ class GraspProcessorModule : public RFModule
             hand_mat_rotation = pose_mat_rotation * grasper_specific_transform_left.submatrix(0,2, 0,2);
         }
 
-        ok3 = dot(hand_mat_rotation.getCol(1), root_z_axis) <= 0.1;
-        if (grasping_hand == WhichHand::HAND_RIGHT)
-        {
-            //  ok if hand z axis points downward
-            ok4 = (dot(hand_mat_rotation.getCol(2), root_z_axis) <= 0.1);
-        }
-        else
-        {
-            //  ok if hand z axis points upwards
-            ok4 = (dot(hand_mat_rotation.getCol(2), root_z_axis) >= -0.1);
-        }
-        ok5 = dot(hand_mat_rotation.getCol(0), root_z_axis) <= 0.1;
+        ok3 = dot(hand_mat_rotation.getCol(1), root_z_axis) <= sin(M_PI/180.0*10);
 
-        return (ok1 && ok2 && ok3 && ok4 && ok5);
+        ok4 = dot(pose_mat_rotation.getCol(2), root_z_axis) <= sin(M_PI/180.0*10);
+
+        return (ok1 && ok2 && ok3 && ok4);
     }
 
     /****************************************************************/

--- a/src/objectsLib.cpp
+++ b/src/objectsLib.cpp
@@ -220,6 +220,20 @@ Vector Superquadric::getOrientationXYZW()
 }
 
 /****************************************************************/
+Vector Superquadric::getRoundness()
+{
+    //  get the superquadric roundness parameters and return as a yarp Vector
+    Vector roundness_vec(2);
+
+    roundness_vec[0] = vtk_superquadric->GetPhiRoundness();
+    roundness_vec[1] = vtk_superquadric->GetThetaRoundness();
+
+    //yDebug() << "Superquadric processor: roundness is " << roundness_vec.toString();
+
+    return roundness_vec;
+}
+
+/****************************************************************/
 GraspPose::GraspPose() : pose_cost_function(2), pose_transform(4,4), pose_rotation(3,3), pose_translation(3), pose_ax_size(3)
 {
     pose_cost_function.zero();

--- a/src/objectsLib.cpp
+++ b/src/objectsLib.cpp
@@ -147,11 +147,17 @@ void Superquadric::set_parameters(const Vector &r)
     //  set coefficients of the superquadric
     //  (dimensions (x0 x1 x2)) (exponents (x3 x4)) (center (x5 x6 x7)) (orientation (x8 x9 x10 x11))
     //  suppose x8 as angle, x9 x10 x11 define the rotation axis
-    vtk_superquadric->SetScale(r[0], r[1], r[2]);
-    vtk_superquadric->SetPhiRoundness(r[3]);
-    vtk_superquadric->SetThetaRoundness(r[4]);
 
-    vtk_sample->SetModelBounds(-2*r[0], 2*r[0], -2*r[1], 2*r[1], -2*r[2], 2*r[2]);
+    // Note: roundness parameter for axes x and y is shared in SQ model,
+    //       but VTK shares axes x and z (ThetaRoundness).
+    //       To get a good display, directions of axes y and z need to be swapped
+    //       => parameters for y and z are inverted and a rotation of -90 degrees around x is added
+
+    vtk_superquadric->SetScale(r[0], r[2], r[1]); // invert y and z
+    vtk_superquadric->SetPhiRoundness(r[3]); // roundness along model z axis (vtk y axis)
+    vtk_superquadric->SetThetaRoundness(r[4]); // common roundness along model x and y axes (vtk x and z axes)
+
+    vtk_sample->SetModelBounds(-r[0], r[0], -r[2], r[2], -r[1], r[1]);
 
     //  center of the superquadric is left to zero, is translated by the vtkTransform
     //  translate and set the pose of the superquadric
@@ -160,7 +166,7 @@ void Superquadric::set_parameters(const Vector &r)
     vtk_transform->Identity();
     vtk_transform->Translate(r[5], r[6], r[7]);
     vtk_transform->RotateWXYZ(r[8], r[9], r[10], r[11]);
-
+    vtk_transform->RotateX(-90.0); // rotate to invert y and z
 }
 
 /****************************************************************/
@@ -186,10 +192,9 @@ Vector Superquadric::getAxesSize()
     Vector axes_vec;
     axes = vtk_superquadric->GetScale();
     axes_vec.resize(3);
-    for (size_t idx = 0; idx<3; idx++)
-    {
-        axes_vec(idx) = axes[idx];
-    }
+    axes_vec(0) = axes[0];
+    axes_vec(1) = axes[2];
+    axes_vec(2) = axes[1];
 
     //  scale the axes wrt superquadric size
     using namespace yarp::math;
@@ -209,6 +214,12 @@ Vector Superquadric::getOrientationXYZW()
 
     orientationWXYZ = vtk_transform->GetOrientationWXYZ();
 
+    vtkSmartPointer<vtkTransform> vtk_transform_tmp = vtkSmartPointer<vtkTransform>::New();
+
+    vtk_transform_tmp->RotateWXYZ(orientationWXYZ[0], orientationWXYZ[1], orientationWXYZ[2], orientationWXYZ[3]);
+    vtk_transform_tmp->RotateX(90.0);
+
+    orientationWXYZ = vtk_transform_tmp->GetOrientationWXYZ();
     orientationWXYZ_vec(0) = orientationWXYZ[1];
     orientationWXYZ_vec(1) = orientationWXYZ[2];
     orientationWXYZ_vec(2) = orientationWXYZ[3];
@@ -225,8 +236,8 @@ Vector Superquadric::getRoundness()
     //  get the superquadric roundness parameters and return as a yarp Vector
     Vector roundness_vec(2);
 
-    roundness_vec[0] = vtk_superquadric->GetPhiRoundness();
-    roundness_vec[1] = vtk_superquadric->GetThetaRoundness();
+    roundness_vec(0) = vtk_superquadric->GetPhiRoundness();
+    roundness_vec(1) = vtk_superquadric->GetThetaRoundness();
 
     //yDebug() << "Superquadric processor: roundness is " << roundness_vec.toString();
 


### PR DESCRIPTION
Add a feature to enable pose ranking from afar to plan the best robot base pose to grasp an object.

- new rpc command `ask_best_base_pose (<x> <y> <z> <ux> <uy> <uz> <t>) <hand> (<np> <no>)`: this command is a way to access an internal function of the module. It can be used to find an optimal base pose that enables grasping an object at pose `(<x> <y> <z> <ux> <uy> <uz> <t>)` with hand `<hand>` ("right" or "left"). It forwards a request to `action-gateway` including the approach parameters (pre-grasp hand pose). Noise parameters (position noise <np> and orientation noise <no>) for a more robust optimal base position planning are optional.

- new rpc command `mobile_grasp_pose <objectNameOPC> <hand>`: this command is similar to `grasp_pose` but with specific communications and ranking process for mobile manipulation with R1. This feature is integrated in the previous pipeline such that it does not modify the previous pose ranking for grasping.

Note: grasping pose pruning conditions concerning the hand axis pointing upwards have been changed to be more flexible (less specific to icub hands). This is the only change that can have an influence on grasping with icub and may require check on icub.

Note: this PR also includes the PR about pseudo-cardinal points #17, which is not described here but included changes in the whole pipeline.
