### PR TITLE
Change minimum required version of VTK to 7.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ find_package(ICUBcontrib REQUIRED)
 list(APPEND CMAKE_MODULE_PATH ${ICUB_MODULE_PATH})
 list(APPEND CMAKE_MODULE_PATH ${ICUBCONTRIB_MODULE_PATH})
 
-find_package(VTK 8.1 REQUIRED)
+find_package(VTK 7.1 REQUIRED)
 include(${VTK_USE_FILE})
 
 include(ICUBcontribHelpers)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Simple superquadric-based grasping pose generator and renderer for iCub
 - [IOL](https://github.com/robotology/iol)
 - [point-cloud-read](https://github.com/robotology/point-cloud-read)
 - [find-superquadric](https://github.com/robotology/find-superquadric)
-- [VTK 8.1](https://www.vtk.org/)
+- [VTK 7.1](https://www.vtk.org/)
 
 ### Installation
 ```


### PR DESCRIPTION
Fixes #22 

Tested on Ubuntu 18.04 with `VTK 7.1`